### PR TITLE
Permutation rewrite rules

### DIFF
--- a/bhv/symbolic.py
+++ b/bhv/symbolic.py
@@ -320,6 +320,10 @@ class PermInvert(SymbolicPermutation):
     def instantiate(self, **kwargs):
         return ~self.p.execute(**kwargs)
 
+    def reduce(self, **kwargs):
+        if isinstance(self.p, PermInvert):
+            return self.p.p
+
 
 class SymbolicBHV(Symbolic, AbstractBHV):
     @classmethod
@@ -440,6 +444,11 @@ class PermApply(SymbolicBHV):
 
     def instantiate(self, **kwargs):
         return self.p.execute(**kwargs)(self.v.execute(**kwargs))
+
+    def reduce(self, **kwargs):
+        if isinstance(self.v, PermApply):
+            if self.v.p == ~self.p or self.p == ~self.v.p:
+                return self.v.v
 
     def distribute(self, **kwargs):
         if isinstance(self.v, Xor) or isinstance(self.v, Majority):

--- a/bhv/symbolic.py
+++ b/bhv/symbolic.py
@@ -266,6 +266,14 @@ class PermVar(SymbolicPermutation):
             return permvars[self.name]
 
 
+@dataclass
+class Identity(SymbolicPermutation):
+    pass
+
+
+SymbolicPermutation.IDENTITY = Identity()
+
+
 randpermid = 0
 def next_perm_id():
     global randpermid
@@ -449,6 +457,10 @@ class PermApply(SymbolicBHV):
         if isinstance(self.v, PermApply):
             if self.v.p == ~self.p or self.p == ~self.v.p:
                 return self.v.v
+        if self.v == SymbolicBHV.ZERO or self.v == SymbolicBHV.ONE:
+            return self.v
+        if self.p == SymbolicPermutation.IDENTITY:
+            return self.v
 
     def distribute(self, **kwargs):
         if isinstance(self.v, Xor) or isinstance(self.v, Majority):

--- a/bhv/symbolic.py
+++ b/bhv/symbolic.py
@@ -455,8 +455,12 @@ class PermApply(SymbolicBHV):
 
     def reduce(self, **kwargs):
         if isinstance(self.v, PermApply):
-            if self.v.p == ~self.p or self.p == ~self.v.p:
-                return self.v.v
+            if isinstance(self.p, PermInvert):
+                if self.p.p == self.v.p:
+                    return self.v.v
+            if isinstance(self.v.p, PermInvert):
+                if self.p == self.v.p.p:
+                    return self.v.v
         if self.v == SymbolicBHV.ZERO or self.v == SymbolicBHV.ONE:
             return self.v
         if self.p == SymbolicPermutation.IDENTITY:

--- a/tests/symbolic.py
+++ b/tests/symbolic.py
@@ -35,6 +35,8 @@ class TestReduction(unittest.TestCase):
 
         self.assertIsNone(p(p(x)).reduce())
         self.assertIsNone(p(q(x)).reduce())
+        self.assertIsNone(p(~q(x)).reduce())
+        self.assertIsNone((~p)(q(x)).reduce())
         self.assertIsNone(p((~~p)(x)).reduce())  # reduce only rewrites outer operation
 
         # double invert = perm

--- a/tests/symbolic.py
+++ b/tests/symbolic.py
@@ -21,10 +21,31 @@ class TestReduction(unittest.TestCase):
     def test_reduce(self):
         x = Var("x")
         y = Var("y")
+        p = PermVar("p")
+        q = PermVar("q")
 
         e = ~(~((x & y) ^ (x & (y & ~y))))
 
         self.assertEqual(e.simplify(), (x & y))
+
+        # perm invert merges
+        self.assertEqual(x, p((~p)(x)).reduce())
+        self.assertEqual(x, (~p)(p(x)).reduce())
+        self.assertEqual(x, (~p)((~~p)(x)).reduce())
+
+        self.assertIsNone(p(p(x)).reduce())
+        self.assertIsNone(p(q(x)).reduce())
+        self.assertIsNone(p((~~p)(x)).reduce())
+
+    def test_simplify(self):
+        x = Var("x")
+        p = PermVar("p")
+
+        # inverse of invert perm is perm
+        self.assertEqual(p(p(x)), p((~~p)(x)).simplify())
+        self.assertEqual(p(x), (~~p)(x).simplify())
+        self.assertEqual(x, (~~~p)(p(x)).simplify())
+        self.assertEqual(p(p(x)), (~~~~p)(p(x)).simplify())
 
     def test_distribute(self):
         # perm


### PR DESCRIPTION
Added an identity permutation
Added following rules for simplifying:
* permuting the zero vector results in zero
* permuting the one vector results in one
* the permutation of its inverse permutation dissolves
* the identity permutation dissolves

Consecutively calling the methods shred and simplify on an expression results in a "normal form" (ignoring Xor commutativity and potential permute commutativety for now) ; a tree of maj over xor over perm over var.